### PR TITLE
fix: set base to root

### DIFF
--- a/src/UI/SatisfactoryPlanner.UI/vite.config.ts
+++ b/src/UI/SatisfactoryPlanner.UI/vite.config.ts
@@ -3,13 +3,10 @@ import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  // depending on your application, base can also be "/"
-  base: "",
+  base: "/",
   plugins: [react(), viteTsconfigPaths()],
   server: {
-    // this ensures that the browser opens upon server start
     open: true,
-    // this sets a default port to 3000
     port: 3000,
   },
 });


### PR DESCRIPTION
On prod when I refresh the page, the assets are loaded relative to the page I'm on. This causes nested pages to try and get assets from the wrong location.