### PR TITLE
Add worlds api test

### DIFF
--- a/build/DatabaseConfiguration.cs
+++ b/build/DatabaseConfiguration.cs
@@ -22,6 +22,6 @@ public class DatabaseConfiguration
         Password = "123qwe!@#QWE";
         Port = port;
         ServerConnectionString = $"Server=127.0.0.1:{Port};User Id={User};Password={Password};";
-        ConnectionString = $"{ServerConnectionString}Database=satisfactory-planner;";
+        ConnectionString = $"{ServerConnectionString}Database=satisfactory-planner;Log Parameters=true;Include Error Detail=true;";
     }
 }

--- a/src/API/SatisfactoryPlanner.API/Program.cs
+++ b/src/API/SatisfactoryPlanner.API/Program.cs
@@ -14,16 +14,24 @@ using SatisfactoryPlanner.API.Configuration.Routing;
 using SatisfactoryPlanner.API.Configuration.Validation;
 using SatisfactoryPlanner.BuildingBlocks.Application;
 using SatisfactoryPlanner.BuildingBlocks.Domain;
+using SatisfactoryPlanner.BuildingBlocks.EventBus;
+using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 using SatisfactoryPlanner.Modules.Production.Infrastructure.Configuration;
 using SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration;
 using SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration;
 using SatisfactoryPlanner.Modules.Worlds.Infrastructure.Configuration;
 using Serilog;
 using Serilog.Context;
+using Serilog.Events;
 using Serilog.Formatting.Compact;
 using ILogger = Serilog.ILogger;
 
 var _logger = new LoggerConfiguration()
+    .MinimumLevel.Information()
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning) // Filter out ASP.NET Core infrastructre logs that are Information and below
+    .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+    .MinimumLevel.Override("Microsoft.AspNetCore.DataProtection", LogEventLevel.Fatal) // See Program.ConfigureAuthenticationService comments for why this is being done
     .Enrich.FromLogContext()
     .WriteTo.Console(
         outputTemplate:
@@ -37,9 +45,12 @@ var _logger = new LoggerConfiguration()
 using (LogContext.PushProperty("Context", "Startup"))
 {
     var _loggerForApi = _logger.ForContext("Module", "API");
-    _loggerForApi.Information("Application started.");
+    _loggerForApi.Information("Application starting...");
 
     var builder = WebApplication.CreateBuilder(args);
+
+    builder.Host.UseSerilog(_logger);
+    Log.Logger = _logger;
 
     ConfigureServices(builder);
 
@@ -49,10 +60,35 @@ using (LogContext.PushProperty("Context", "Startup"))
 
     var app = builder.Build();
 
-    Configure(app, app.Environment, _logger, builder.Configuration);
+    var eventsBus = new InMemoryEventBusClient(_logger);
+
+    var lifeTime = app.Lifetime;
+    lifeTime.ApplicationStopping.Register(() =>
+    {
+        using (LogContext.PushProperty("Context", "Stopping"))
+        {
+            _loggerForApi.Information("Application stopping...");
+            ProductionStartup.Stop();
+            ResourcesStartup.Stop();
+            WorldsStartup.Stop();
+            UserAccessStartup.Stop();
+            eventsBus.Stop();
+        }
+    });
+    lifeTime.ApplicationStopped.Register(() =>
+    {
+        using (LogContext.PushProperty("Context", "Stopped"))
+        {
+            _loggerForApi.Information("Application stopped");
+            _logger.Dispose();
+        }
+    });
+
+    Configure(app, app.Environment, _logger, builder.Configuration, eventsBus);
 
     app.MapControllers();
 
+    _loggerForApi.Information("Application started");
     app.Run();
 }
 
@@ -124,7 +160,7 @@ static void RegisterModules(ContainerBuilder containerBuilder)
     containerBuilder.RegisterModule(new UserAccessAutofacModule());
 }
 
-static void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger logger, ConfigurationManager configuration)
+static void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger logger, ConfigurationManager configuration, IEventsBus eventsBus)
 {
     app.UseCors(builder =>
         builder
@@ -133,7 +169,7 @@ static void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger 
             .AllowAnyMethod()
     );
 
-    InitializeModules(app, logger, configuration);
+    StartModules(app, logger, configuration, eventsBus);
 
     app.UseMiddleware<CorrelationMiddleware>();
 
@@ -150,6 +186,8 @@ static void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger 
 
     //app.UseHttpsRedirection();
 
+    app.UseSerilogRequestLogging();
+
     app.UseAuthentication();
 
     // To be used by WorldAuthorization to get world id from the body of the request
@@ -161,32 +199,37 @@ static void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger 
     app.UseAuthorization();
 }
 
-static void InitializeModules(IApplicationBuilder app, ILogger logger, ConfigurationManager configuration)
+static void StartModules(IApplicationBuilder app, ILogger logger, ConfigurationManager configuration, IEventsBus eventsBus)
 {
     var container = app.ApplicationServices.GetAutofacRoot();
     var executionContextAccessor = container.Resolve<IExecutionContextAccessor>();
     var connectionString = configuration.GetConnectionString("SatisfactoryPlanner") ?? throw new InvalidOperationException("SatisfactoryPlanner connection string not defined.");
 
-    ProductionStartup.Initialize(
+    ProductionStartup.Start(
         connectionString,
         executionContextAccessor,
-        logger
+        logger,
+        eventsBus
     );
 
-    ResourcesStartup.Initialize(
+    ResourcesStartup.Start(
         connectionString,
         executionContextAccessor,
-        logger
+        logger,
+        eventsBus
     );
 
-    UserAccessStartup.Initialize(
+    UserAccessStartup.Start(
         connectionString,
         executionContextAccessor,
-        logger);
+        logger,
+        eventsBus
+    );
 
-    WorldsStartup.Initialize(
+    WorldsStartup.Start(
         connectionString,
         executionContextAccessor,
-        logger
+        logger,
+        eventsBus
     );
 }

--- a/src/API/SatisfactoryPlanner.API/SatisfactoryPlanner.API.csproj
+++ b/src/API/SatisfactoryPlanner.API/SatisfactoryPlanner.API.csproj
@@ -26,6 +26,7 @@
 		<PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
 		<PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -39,6 +40,12 @@
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
 		<ProjectReference Include="..\..\BuildingBlocks\Domain\SatisfactoryPlanner.BuildingBlocks.Domain.csproj">
+			<PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
+		<ProjectReference Include="..\..\BuildingBlocks\Infrastructure\SatisfactoryPlanner.BuildingBlocks.Infrastructure.csproj" >
+			<PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
+		<ProjectReference Include="..\..\BuildingBlocks\SatisfactoryPlanner.BuildingBlocks.EventBus\SatisfactoryPlanner.BuildingBlocks.EventBus.csproj" >
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
 		<ProjectReference Include="..\..\Modules\Production\Application\SatisfactoryPlanner.Modules.Production.Application.csproj">

--- a/src/API/Tests/IntegrationTests/DatabaseClearer.cs
+++ b/src/API/Tests/IntegrationTests/DatabaseClearer.cs
@@ -1,6 +1,7 @@
 ﻿using Npgsql;
 using Production = SatisfactoryPlanner.Modules.Production.IntegrationTests.SeedWork;
 using UserAccess = SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.SeedWork;
+using Worlds = SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork;
 
 namespace SatisfactoryPlanner.API.IntegrationTests
 {
@@ -13,6 +14,7 @@ namespace SatisfactoryPlanner.API.IntegrationTests
             // Call out to each module's integration test project so that the api tests don't need to stay in sync with all module changes.
             // Assuming each integration test project knows how to clear its own database data between tests.
             await UserAccess.DatabaseClearer.Clear(connection);
+            await Worlds.DatabaseClearer.Clear(connection);
             await Production.DatabaseClearer.Clear(connection);
 
             // TODO add other module's database clearers 

--- a/src/API/Tests/IntegrationTests/DatabaseClearer.cs
+++ b/src/API/Tests/IntegrationTests/DatabaseClearer.cs
@@ -2,6 +2,7 @@
 using Production = SatisfactoryPlanner.Modules.Production.IntegrationTests.SeedWork;
 using UserAccess = SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.SeedWork;
 using Worlds = SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork;
+using Resources = SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 
 namespace SatisfactoryPlanner.API.IntegrationTests
 {
@@ -15,9 +16,8 @@ namespace SatisfactoryPlanner.API.IntegrationTests
             // Assuming each integration test project knows how to clear its own database data between tests.
             await UserAccess.DatabaseClearer.Clear(connection);
             await Worlds.DatabaseClearer.Clear(connection);
+            await Resources.DatabaseClearer.Clear(connection);
             await Production.DatabaseClearer.Clear(connection);
-
-            // TODO add other module's database clearers 
         }
     }
 }

--- a/src/API/Tests/IntegrationTests/Endpoints/Production/ProcessedItems/GetItemRecipes.cs
+++ b/src/API/Tests/IntegrationTests/Endpoints/Production/ProcessedItems/GetItemRecipes.cs
@@ -2,7 +2,6 @@
 using SatisfactoryPlanner.API.Endpoints.Production.ProcessedItems;
 using SatisfactoryPlanner.API.IntegrationTests.Endpoints.UserAccess.Users;
 using System.Net;
-using System.Net.Http.Json;
 
 namespace SatisfactoryPlanner.API.IntegrationTests.Endpoints.Production.ProcessedItems
 {
@@ -27,7 +26,7 @@ namespace SatisfactoryPlanner.API.IntegrationTests.Endpoints.Production.Processe
                 {
                     response.Should().HaveStatusCode(HttpStatusCode.OK);
 
-                    var responseContent = (await response.Content.ReadFromJsonAsync<GetItemRecipesResponse>())!;
+                    var responseContent = (await response.ReadContentAsync<GetItemRecipesResponse>())!;
                     var data = responseContent.Data;
                     data.Should().NotBeNull();
                 }

--- a/src/API/Tests/IntegrationTests/Endpoints/Production/ProcessedItems/GetItemsToProcess.cs
+++ b/src/API/Tests/IntegrationTests/Endpoints/Production/ProcessedItems/GetItemsToProcess.cs
@@ -1,7 +1,6 @@
 ﻿using SatisfactoryPlanner.API.Endpoints.Production.ProcessedItems;
 using SatisfactoryPlanner.API.IntegrationTests.Endpoints.UserAccess.Users;
 using System.Net;
-using System.Net.Http.Json;
 
 namespace SatisfactoryPlanner.API.IntegrationTests.Endpoints.Production.ProcessedItems
 {
@@ -24,7 +23,7 @@ namespace SatisfactoryPlanner.API.IntegrationTests.Endpoints.Production.Processe
 
                 response.Should().HaveStatusCode(HttpStatusCode.OK);
 
-                var responseContent = (await response.Content.ReadFromJsonAsync<GetItemsToProcessReponse>())!;
+                var responseContent = (await response.ReadContentAsync<GetItemsToProcessReponse>())!;
                 var items = responseContent.Items;
                 items.Should().NotBeEmpty();
             }

--- a/src/API/Tests/IntegrationTests/Endpoints/UserAccess/Users/CreateCurrentUser.cs
+++ b/src/API/Tests/IntegrationTests/Endpoints/UserAccess/Users/CreateCurrentUser.cs
@@ -25,7 +25,7 @@ namespace SatisfactoryPlanner.API.IntegrationTests.Endpoints.UserAccess.Users
 
                 response.Should().HaveStatusCode(HttpStatusCode.Created);
 
-                var responseContent = (await response.Content.ReadFromJsonAsync<CreateCurrentUserResponse>())!;
+                var responseContent = (await response.ReadContentAsync<CreateCurrentUserResponse>())!;
                 responseContent.UserId.Should().NotBeEmpty();
             }
         }

--- a/src/API/Tests/IntegrationTests/Endpoints/Worlds/GetCurrentPioneerWorlds.cs
+++ b/src/API/Tests/IntegrationTests/Endpoints/Worlds/GetCurrentPioneerWorlds.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions.Execution;
+using SatisfactoryPlanner.API.IntegrationTests.Endpoints.UserAccess.Users;
+using SatisfactoryPlanner.BuildingBlocks.IntegrationTests.Probing;
+using SatisfactoryPlanner.Modules.Worlds.Application.Worlds.GetCurrentPioneerWorlds;
+using System.Net;
+
+namespace SatisfactoryPlanner.API.IntegrationTests.Endpoints.Production.ProcessedItems
+{
+    public static class GetCurrentPioneerWorlds
+    {
+        public static async Task<HttpResponseMessage> Execute(HttpClient client)
+            => await client.GetAsync("api/worlds/worlds/@me");
+
+        [TestFixture]
+        public class Tests : IntegrationTest
+        {
+            [Test]
+            public async Task HappyPath()
+            {
+                // Need a user so we pass the permissions check... nearly every endpoint test will need this
+                // TODO should we add a test for each endpoint that it has the right authorization? Maybe we can check its attributes?
+                await CreateCurrentUser.Execute(Client);
+
+                var response = await GetEventually(new Probe(Client), 10000);
+
+                using (new AssertionScope())
+                {
+                    response.Should().HaveStatusCode(HttpStatusCode.OK);
+
+                    var responseContent = (await response.ReadContentAsync<List<PioneerWorldDto>>())!;
+                    responseContent.Should().HaveCount(1);
+
+                    var starterWorld = responseContent[0];
+                    starterWorld.Id.Should().NotBeEmpty();
+                    starterWorld.Name.Should().NotBeNullOrEmpty();
+                }
+            }
+        }
+
+        public class Probe(HttpClient client) : IProbe<HttpResponseMessage>
+        {
+            private readonly HttpClient _client = client;
+
+            public async Task<bool> IsSatisfiedAsync(HttpResponseMessage sample)
+            {
+                if (sample?.IsSuccessStatusCode != true)
+                    return false;
+
+                var content = (await sample.ReadContentAsync<List<PioneerWorldDto>>())!;
+                return content.Count != 0;
+            }
+
+            public async Task<HttpResponseMessage> GetSampleAsync()
+            {
+                return await Execute(_client);
+            }
+
+            public string DescribeFailureTo() => "Cannot get current pioneer worlds.";
+        }
+    }
+}

--- a/src/API/Tests/IntegrationTests/HttpResponseMessageExtensions.cs
+++ b/src/API/Tests/IntegrationTests/HttpResponseMessageExtensions.cs
@@ -12,7 +12,16 @@ namespace SatisfactoryPlanner.API.IntegrationTests
         public static async Task<T> ReadContentAsync<T>(this HttpResponseMessage message)
         {
             var content = await message.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<T>(content, Options)!;
+
+            try
+            {
+                return JsonSerializer.Deserialize<T>(content, Options)!;
+            }
+            catch
+            {
+                Console.WriteLine($"Failed to read content: {content}");
+                throw;
+            }
         }
     }
 }

--- a/src/API/Tests/IntegrationTests/HttpResponseMessageExtensions.cs
+++ b/src/API/Tests/IntegrationTests/HttpResponseMessageExtensions.cs
@@ -1,10 +1,18 @@
-﻿using System.Net.Http.Json;
+﻿using System.Text.Json;
 
 namespace SatisfactoryPlanner.API.IntegrationTests
 {
     public static class HttpResponseMessageExtensions
     {
+        private static readonly JsonSerializerOptions Options = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
         public static async Task<T> ReadContentAsync<T>(this HttpResponseMessage message)
-            => (await message.Content.ReadFromJsonAsync<T>())!;
+        {
+            var content = await message.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<T>(content, Options)!;
+        }
     }
 }

--- a/src/API/Tests/IntegrationTests/IntegrationTest.cs
+++ b/src/API/Tests/IntegrationTests/IntegrationTest.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
+using SatisfactoryPlanner.BuildingBlocks.IntegrationTests.Probing;
 
 namespace SatisfactoryPlanner.API.IntegrationTests
 {
@@ -47,13 +48,21 @@ namespace SatisfactoryPlanner.API.IntegrationTests
             await DatabaseClearer.Clear(ConnectionString);
 
             // since tests run sequentially, each test can manipulate this user to perform their test and it will reset before each test so the tests don't affect each other
-            AuthenticatedUser.Reset(); 
+            AuthenticatedUser.Reset();
         }
 
         [OneTimeTearDown]
         public void OnShutdown()
         {
             Client.Dispose();
+        }
+
+        protected static async Task<T> GetEventually<T>(IProbe<T> probe, int timeout)
+            where T : class
+        {
+            var poller = new Poller(timeout);
+
+            return await poller.GetAsync(probe);
         }
     }
 }

--- a/src/API/Tests/IntegrationTests/SatisfactoryPlanner.API.IntegrationTests.csproj
+++ b/src/API/Tests/IntegrationTests/SatisfactoryPlanner.API.IntegrationTests.csproj
@@ -29,10 +29,22 @@
 		<ProjectReference Include="..\..\..\Modules\Production\Application\SatisfactoryPlanner.Modules.Production.Application.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\Production\Infrastructure\SatisfactoryPlanner.Modules.Production.Infrastructure.csproj" >
+			<PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
 		<ProjectReference Include="..\..\..\Modules\Production\Tests\IntegrationTests\SatisfactoryPlanner.Modules.Production.IntegrationTests.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\Resources\Infrastructure\SatisfactoryPlanner.Modules.Resources.Infrastructure.csproj" >
+			<PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\Resources\Tests\IntegrationTests\SatisfactoryPlanner.Modules.Resources.IntegrationTests.csproj">
+		  <PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
 		<ProjectReference Include="..\..\..\Modules\UserAccess\Application\SatisfactoryPlanner.Modules.UserAccess.Application.csproj">
+			<PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\UserAccess\Infrastructure\SatisfactoryPlanner.Modules.UserAccess.Infrastructure.csproj" >
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
 		<ProjectReference Include="..\..\..\Modules\UserAccess\Tests\IntegrationTests\SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.csproj">
@@ -40,6 +52,9 @@
 		</ProjectReference>
 		<ProjectReference Include="..\..\..\Modules\Worlds\Application\SatisfactoryPlanner.Modules.Worlds.Application.csproj">
 		  <PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\Worlds\Infrastructure\SatisfactoryPlanner.Modules.Worlds.Infrastructure.csproj" >
+			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
 		<ProjectReference Include="..\..\..\Modules\Worlds\Tests\IntegrationTests\SatisfactoryPlanner.Modules.Worlds.IntegrationTests.csproj">
 		  <PrivateAssets>All</PrivateAssets>

--- a/src/API/Tests/IntegrationTests/SatisfactoryPlanner.API.IntegrationTests.csproj
+++ b/src/API/Tests/IntegrationTests/SatisfactoryPlanner.API.IntegrationTests.csproj
@@ -38,6 +38,12 @@
 		<ProjectReference Include="..\..\..\Modules\UserAccess\Tests\IntegrationTests\SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\Worlds\Application\SatisfactoryPlanner.Modules.Worlds.Application.csproj">
+		  <PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
+		<ProjectReference Include="..\..\..\Modules\Worlds\Tests\IntegrationTests\SatisfactoryPlanner.Modules.Worlds.IntegrationTests.csproj">
+		  <PrivateAssets>All</PrivateAssets>
+		</ProjectReference>
 		<ProjectReference Include="..\..\SatisfactoryPlanner.API\SatisfactoryPlanner.API.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>

--- a/src/BuildingBlocks/Application/Events/DomainEventNotificationBase.cs
+++ b/src/BuildingBlocks/Application/Events/DomainEventNotificationBase.cs
@@ -3,10 +3,10 @@ using System;
 
 namespace SatisfactoryPlanner.BuildingBlocks.Application.Events
 {
-    public class DomainNotificationBase<T> : IDomainEventNotification<T>
+    public class DomainEventNotificationBase<T> : IDomainEventNotification<T>
         where T : IDomainEvent
     {
-        public DomainNotificationBase(T domainEvent, Guid id)
+        public DomainEventNotificationBase(T domainEvent, Guid id)
         {
             Id = id;
             DomainEvent = domainEvent;

--- a/src/BuildingBlocks/Infrastructure/Configuration/Processing/LoggingNotificationHandlerDecorator.cs
+++ b/src/BuildingBlocks/Infrastructure/Configuration/Processing/LoggingNotificationHandlerDecorator.cs
@@ -1,0 +1,42 @@
+﻿using MediatR;
+using SatisfactoryPlanner.BuildingBlocks.Application.Events;
+using Serilog;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SatisfactoryPlanner.BuildingBlocks.Infrastructure.Configuration.Processing
+{
+    public class LoggingNotificationHandlerDecorator<T>(INotificationHandler<T> decorated, ILogger logger) : INotificationHandler<T>
+        where T : INotification
+    {
+        public async Task Handle(T notification, CancellationToken cancellationToken)
+        {
+            var notificationName = notification.GetType().Name;
+
+            try
+            {
+                if (notification is IDomainEventNotification)
+                    logger.Information("Sending {Notification}", notificationName);
+                else
+                    logger.Information("Publishing {Event}", notificationName);
+
+                await decorated.Handle(notification, cancellationToken);
+
+                if (notification is IDomainEventNotification)
+                    logger.Information("Successfully sent {Notification}", notificationName);
+                else
+                    logger.Information("Published {Event}", notificationName);
+            }
+            catch (Exception exception)
+            {
+                if (notification is IDomainEventNotification)
+                    logger.Error(exception, "Sending {Notification} failed", notificationName);
+                else
+                    logger.Error(exception, "Publishing {Event} failed", notificationName);
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/EventBus/IEventsBus.cs
+++ b/src/BuildingBlocks/Infrastructure/EventBus/IEventsBus.cs
@@ -11,6 +11,9 @@ namespace SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus
         void Subscribe<T>(IIntegrationEventHandler<T> handler)
             where T : IntegrationEvent;
 
-        void StartConsuming();
+        /// <summary>
+        /// Stop the event bus and clean up event subscriptions.
+        /// </summary>
+        void Stop();
     }
 }

--- a/src/BuildingBlocks/SatisfactoryPlanner.BuildingBlocks.EventBus/InMemoryEventBusClient.cs
+++ b/src/BuildingBlocks/SatisfactoryPlanner.BuildingBlocks.EventBus/InMemoryEventBusClient.cs
@@ -1,24 +1,15 @@
 ﻿using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
-using Serilog;
 using System.Threading.Tasks;
 
 namespace SatisfactoryPlanner.BuildingBlocks.EventBus
 {
     public class InMemoryEventBusClient : IEventsBus
     {
-        private readonly ILogger _logger;
-
-        public InMemoryEventBusClient(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        public void Dispose() { }
+        private bool disposedValue;
 
         public async Task Publish<T>(T @event)
             where T : IntegrationEvent
         {
-            _logger.Information("Publishing {Event}", @event.GetType().FullName);
             await InMemoryEventBus.Instance.Publish(@event);
         }
 
@@ -28,6 +19,25 @@ namespace SatisfactoryPlanner.BuildingBlocks.EventBus
             InMemoryEventBus.Instance.Subscribe(handler);
         }
 
-        public void StartConsuming() { }
+        public void Stop() => InMemoryEventBus.Instance.Reset();
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            System.GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/AssertErrorException.cs
+++ b/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/AssertErrorException.cs
@@ -1,0 +1,18 @@
+﻿namespace SatisfactoryPlanner.BuildingBlocks.IntegrationTests.Probing
+{
+    public class AssertErrorException : Exception
+    {
+        public AssertErrorException() : base()
+        {
+        }
+
+        public AssertErrorException(string? message)
+            : base(message)
+        {
+        }
+
+        public AssertErrorException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/IProbe.cs
+++ b/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/IProbe.cs
@@ -1,0 +1,20 @@
+﻿namespace SatisfactoryPlanner.BuildingBlocks.IntegrationTests.Probing
+{
+    public interface IProbe
+    {
+        bool IsSatisfied();
+
+        Task SampleAsync();
+
+        string DescribeFailureTo();
+    }
+
+    public interface IProbe<T>
+    {
+        Task<bool> IsSatisfiedAsync(T sample);
+
+        Task<T> GetSampleAsync();
+
+        string DescribeFailureTo();
+    }
+}

--- a/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/Poller.cs
+++ b/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/Poller.cs
@@ -1,0 +1,43 @@
+﻿namespace SatisfactoryPlanner.BuildingBlocks.IntegrationTests.Probing
+{
+    public class Poller(int timeoutMillis)
+    {
+        private readonly int _timeoutMillis = timeoutMillis;
+        private readonly int _pollDelayMillis = 1000;
+
+        public async Task CheckAsync(IProbe probe)
+        {
+            var timeout = new Timeout(_timeoutMillis);
+            while (!probe.IsSatisfied())
+            {
+                if (timeout.HasTimedOut())
+                    throw new AssertErrorException(DescribeFailureOf(probe));
+
+                await Task.Delay(_pollDelayMillis);
+                await probe.SampleAsync();
+            }
+        }
+
+        public async Task<T> GetAsync<T>(IProbe<T> probe)
+            where T : class
+        {
+            var timeout = new Timeout(_timeoutMillis);
+            var sample = await probe.GetSampleAsync();
+
+            while (!(await probe.IsSatisfiedAsync(sample)))
+            {
+                if (timeout.HasTimedOut())
+                    throw new AssertErrorException(DescribeFailureOf(probe));
+
+                await Task.Delay(_pollDelayMillis);
+                sample = await probe.GetSampleAsync();
+            }
+
+            return sample;
+        }
+
+        private static string DescribeFailureOf(IProbe probe) => probe.DescribeFailureTo();
+
+        private static string DescribeFailureOf<T>(IProbe<T> probe) => DescribeFailureOf(probe);
+    }
+}

--- a/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/Timeout.cs
+++ b/src/BuildingBlocks/Tests/SatisfactoryPlanner.BuildingBlocks.IntegrationTests/Probing/Timeout.cs
@@ -1,0 +1,9 @@
+﻿namespace SatisfactoryPlanner.BuildingBlocks.IntegrationTests.Probing
+{
+    public class Timeout(int duration)
+    {
+        private readonly DateTime _endTime = DateTime.Now.AddMilliseconds(duration);
+
+        public bool HasTimedOut() => DateTime.Now > _endTime;
+    }
+}

--- a/src/Modules/Production/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
+++ b/src/Modules/Production/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
@@ -1,16 +1,13 @@
 ﻿using Autofac;
-using SatisfactoryPlanner.BuildingBlocks.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 
 namespace SatisfactoryPlanner.Modules.Production.Infrastructure.Configuration.EventsBus
 {
-    internal class EventsBusModule : Module
+    internal class EventsBusModule(IEventsBus eventsBus) : Module
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<InMemoryEventBusClient>()
-                .As<IEventsBus>()
-                .SingleInstance();
+            builder.RegisterInstance(eventsBus).As<IEventsBus>();
         }
     }
 }

--- a/src/Modules/Production/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
+++ b/src/Modules/Production/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
@@ -41,7 +41,7 @@ namespace SatisfactoryPlanner.Modules.Production.Infrastructure.Configuration.Pr
 
                     var result = await _decorated.Handle(command, cancellationToken);
 
-                    _logger.Information("Command processed successfully, result {Result}", result);
+                    _logger.Information("Command {Command} processed successfully, result {Result}", command.GetType().Name, result);
 
                     return result;
                 }

--- a/src/Modules/Production/Infrastructure/Configuration/Processing/ProcessingModule.cs
+++ b/src/Modules/Production/Infrastructure/Configuration/Processing/ProcessingModule.cs
@@ -30,18 +30,14 @@ namespace SatisfactoryPlanner.Modules.Production.Infrastructure.Configuration.Pr
                 .InstancePerLifetimeScope();
 
             builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
 
-            builder.RegisterGenericDecorator(
-                typeof(DomainEventsDispatcherNotificationHandlerDecorator<>),
-                typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(DomainEventsDispatcherNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(LoggingNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
 
             builder.RegisterAssemblyTypes(Assemblies.Application)
                 .AsClosedTypesOf(typeof(IDomainEventNotification<>))

--- a/src/Modules/Production/Infrastructure/Configuration/Quartz/QuartzStartup.cs
+++ b/src/Modules/Production/Infrastructure/Configuration/Quartz/QuartzStartup.cs
@@ -26,21 +26,21 @@ namespace SatisfactoryPlanner.Modules.Production.Infrastructure.Configuration.Qu
             logger.Information("Quartz started.");
         }
 
-        internal static void Shutdown() => _scheduler.Shutdown();
+        internal static void Shutdown() => _scheduler?.Shutdown().Wait();
 
         private static IScheduler StartScheduler(ILogger logger)
         {
+            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
+
             var schedulerConfiguration = new NameValueCollection
             {
                 {
-                    "quartz.scheduler.instanceName", "SatisfactoryPlanner"
+                    "quartz.scheduler.instanceName", "SatisfactoryPlanner.Production"
                 }
             };
 
             var schedulerFactory = new StdSchedulerFactory(schedulerConfiguration);
             var scheduler = schedulerFactory.GetScheduler().GetAwaiter().GetResult();
-
-            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
 
             scheduler.Start().GetAwaiter().GetResult();
 

--- a/src/Modules/Production/Tests/IntegrationTests/SatisfactoryPlanner.Modules.Production.IntegrationTests.csproj
+++ b/src/Modules/Production/Tests/IntegrationTests/SatisfactoryPlanner.Modules.Production.IntegrationTests.csproj
@@ -29,6 +29,9 @@
     <ProjectReference Include="..\..\..\..\BuildingBlocks\Domain\SatisfactoryPlanner.BuildingBlocks.Domain.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\BuildingBlocks\Infrastructure\SatisfactoryPlanner.BuildingBlocks.Infrastructure.csproj" >
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\BuildingBlocks\Tests\SatisfactoryPlanner.BuildingBlocks.IntegrationTests\SatisfactoryPlanner.BuildingBlocks.IntegrationTests.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>

--- a/src/Modules/Production/Tests/IntegrationTests/SeedWork/IntegrationTest.cs
+++ b/src/Modules/Production/Tests/IntegrationTests/SeedWork/IntegrationTest.cs
@@ -3,6 +3,7 @@ using Npgsql;
 using NSubstitute;
 using SatisfactoryPlanner.BuildingBlocks.Application;
 using SatisfactoryPlanner.BuildingBlocks.Domain;
+using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
 using SatisfactoryPlanner.Modules.Production.Application.Contracts;
 using SatisfactoryPlanner.Modules.Production.Infrastructure;
@@ -14,6 +15,8 @@ namespace SatisfactoryPlanner.Modules.Production.IntegrationTests.SeedWork
     public class IntegrationTest
     {
         protected string ConnectionString { get; private set; } = null!;
+
+        public IEventsBus EventsBus { get; private set; } = default!;
 
         protected ILogger Logger { get; private set; } = null!;
 
@@ -36,11 +39,13 @@ namespace SatisfactoryPlanner.Modules.Production.IntegrationTests.SeedWork
 
             Logger = Substitute.For<ILogger>();
             ExecutionContext = new ExecutionContextMock(Guid.NewGuid());
+            EventsBus = Substitute.For<IEventsBus>();
 
-            ProductionStartup.Initialize(
+            ProductionStartup.Start(
                 ConnectionString,
                 ExecutionContext,
-                Logger);
+                Logger,
+                EventsBus);
 
             ProductionModule = new ProductionModule();
         }

--- a/src/Modules/Resources/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
+++ b/src/Modules/Resources/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
@@ -1,16 +1,13 @@
 ﻿using Autofac;
-using SatisfactoryPlanner.BuildingBlocks.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 
 namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.EventsBus
 {
-    internal class EventsBusModule : Module
+    internal class EventsBusModule(IEventsBus eventsBus) : Module
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<InMemoryEventBusClient>()
-                .As<IEventsBus>()
-                .SingleInstance();
+            builder.RegisterInstance(eventsBus).As<IEventsBus>();
         }
     }
 }

--- a/src/Modules/Resources/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
+++ b/src/Modules/Resources/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
@@ -41,7 +41,7 @@ namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.Pro
 
                     var result = await _decorated.Handle(command, cancellationToken);
 
-                    _logger.Information("Command processed successfully, result {Result}", result);
+                    _logger.Information("Command {Command} processed successfully, result {Result}", command.GetType().Name, result);
 
                     return result;
                 }

--- a/src/Modules/Resources/Infrastructure/Configuration/Processing/ProcessingModule.cs
+++ b/src/Modules/Resources/Infrastructure/Configuration/Processing/ProcessingModule.cs
@@ -30,18 +30,14 @@ namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.Pro
                 .InstancePerLifetimeScope();
 
             builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
 
-            builder.RegisterGenericDecorator(
-                typeof(DomainEventsDispatcherNotificationHandlerDecorator<>),
-                typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(DomainEventsDispatcherNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(LoggingNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
 
             builder.RegisterAssemblyTypes(Assemblies.Application)
                 .AsClosedTypesOf(typeof(IDomainEventNotification<>))

--- a/src/Modules/Resources/Infrastructure/Configuration/Quartz/QuartzStartup.cs
+++ b/src/Modules/Resources/Infrastructure/Configuration/Quartz/QuartzStartup.cs
@@ -26,21 +26,21 @@ namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.Qua
             logger.Information("Quartz started.");
         }
 
-        internal static void Shutdown() => _scheduler.Shutdown();
+        internal static void Shutdown() => _scheduler?.Shutdown().Wait();
 
         private static IScheduler StartScheduler(ILogger logger)
         {
+            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
+
             var schedulerConfiguration = new NameValueCollection
             {
                 {
-                    "quartz.scheduler.instanceName", "SatisfactoryPlanner"
+                    "quartz.scheduler.instanceName", "SatisfactoryPlanner.Resources"
                 }
             };
 
             var schedulerFactory = new StdSchedulerFactory(schedulerConfiguration);
             var scheduler = schedulerFactory.GetScheduler().GetAwaiter().GetResult();
-
-            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
 
             scheduler.Start().GetAwaiter().GetResult();
 

--- a/src/Modules/Resources/Infrastructure/Configuration/ResourcesStartup.cs
+++ b/src/Modules/Resources/Infrastructure/Configuration/ResourcesStartup.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using SatisfactoryPlanner.BuildingBlocks.Application;
 using SatisfactoryPlanner.BuildingBlocks.Infrastructure;
+using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 using SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.DataAccess;
 using SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.Domain;
 using SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration.EventsBus;
@@ -17,17 +18,16 @@ namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration
 {
     /// <summary>
     ///     Initialize the services and configurations for the Resources module.
-    ///     This will set up the logging and dependency injection for this module.
-    ///     Should be called from the main application Startup.
+    ///     Should be called from the main application startup.
     /// </summary>
-    public class ResourcesStartup
+    public static class ResourcesStartup
     {
-        public static void Initialize(string connectionString, IExecutionContextAccessor executionContextAccessor,
-            ILogger logger)
+        public static void Start(string connectionString, IExecutionContextAccessor executionContextAccessor,
+            ILogger logger, IEventsBus eventsBus)
         {
             var moduleLogger = logger.ForContext("Module", "Resources");
 
-            ConfigureCompositionRoot(connectionString, executionContextAccessor, logger);
+            ConfigureCompositionRoot(connectionString, executionContextAccessor, logger, eventsBus);
 
             QuartzStartup.Initialize(moduleLogger);
             EventsBusStartup.Initialize(moduleLogger);
@@ -39,7 +39,7 @@ namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration
         }
 
         private static void ConfigureCompositionRoot(string connectionString,
-            IExecutionContextAccessor executionContextAccessor, ILogger logger)
+            IExecutionContextAccessor executionContextAccessor, ILogger logger, IEventsBus eventsBus)
         {
             var containerBuilder = new ContainerBuilder();
 
@@ -49,7 +49,7 @@ namespace SatisfactoryPlanner.Modules.Resources.Infrastructure.Configuration
             containerBuilder.RegisterModule(new DataAccessModule(connectionString, loggerFactory));
             containerBuilder.RegisterModule(new DomainModule());
             containerBuilder.RegisterModule(new ProcessingModule());
-            containerBuilder.RegisterModule(new EventsBusModule());
+            containerBuilder.RegisterModule(new EventsBusModule(eventsBus));
             containerBuilder.RegisterModule(new MediatorModule());
 
             var domainNotificationsMap = new BiDictionary<string, Type>();

--- a/src/Modules/Resources/Tests/IntegrationTests/SatisfactoryPlanner.Modules.Resources.IntegrationTests.csproj
+++ b/src/Modules/Resources/Tests/IntegrationTests/SatisfactoryPlanner.Modules.Resources.IntegrationTests.csproj
@@ -25,6 +25,9 @@
 		<ProjectReference Include="..\..\..\..\BuildingBlocks\Application\SatisfactoryPlanner.BuildingBlocks.Application.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
+		<ProjectReference Include="..\..\..\..\BuildingBlocks\Infrastructure\SatisfactoryPlanner.BuildingBlocks.Infrastructure.csproj" >
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
 		<ProjectReference Include="..\..\..\..\BuildingBlocks\Tests\SatisfactoryPlanner.BuildingBlocks.IntegrationTests\SatisfactoryPlanner.BuildingBlocks.IntegrationTests.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>

--- a/src/Modules/Resources/Tests/IntegrationTests/SeedWork/DatabaseClearer.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/SeedWork/DatabaseClearer.cs
@@ -1,0 +1,29 @@
+﻿using Dapper;
+using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
+using System.Data;
+
+namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork
+{
+    public static class DatabaseClearer
+    {
+        public static async Task Clear(IDbConnection connection)
+        {
+            /* Not clearing the following tables since they're pre-loaded reference tables:
+             *   extractor_allowed_resources,
+             *   extractors,
+             *   nodes,
+             *   resource_forms,
+             *   resources
+             */
+
+            var sql = ClearDatabaseSqlGenerator.InSchema("resources")
+                .ClearTable("inbox_messages")
+                .ClearTable("internal_commands")
+                .ClearTable("outbox_messages")
+                .ClearTable("world_nodes")
+                .GenerateSql();
+
+            await connection.ExecuteScalarAsync(sql);
+        }
+    }
+}

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/DecreaseExtractionRateTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/DecreaseExtractionRateTests.cs
@@ -7,7 +7,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class DecreaseExtractionRateTests : TestBase
+    public class DecreaseExtractionRateTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/DismantleExtractorTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/DismantleExtractorTests.cs
@@ -6,7 +6,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class DismantleExtractorTests : TestBase
+    public class DismantleExtractorTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/DowngradeExtractorTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/DowngradeExtractorTests.cs
@@ -6,7 +6,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class DowngradeExtractorTests : TestBase
+    public class DowngradeExtractorTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/GetWorldNodeDetailsTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/GetWorldNodeDetailsTests.cs
@@ -5,7 +5,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    internal class GetWorldNodeDetailsTests : TestBase
+    internal class GetWorldNodeDetailsTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/IncreaseExtractionRateTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/IncreaseExtractionRateTests.cs
@@ -6,7 +6,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class IncreaseExtractionRateTests : TestBase
+    public class IncreaseExtractionRateTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/SpawnWorldNodesTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/SpawnWorldNodesTests.cs
@@ -5,7 +5,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class SpawnWorldNodesTests : TestBase
+    public class SpawnWorldNodesTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/TapWorldNodeTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/TapWorldNodeTests.cs
@@ -7,7 +7,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class TapWorldNodeTests : TestBase
+    public class TapWorldNodeTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/UpgradeExtractorTests.cs
+++ b/src/Modules/Resources/Tests/IntegrationTests/WorldNodes/UpgradeExtractorTests.cs
@@ -6,7 +6,7 @@ using SatisfactoryPlanner.Modules.Resources.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Resources.IntegrationTests.WorldNodes
 {
     [TestFixture]
-    public class UpgradeExtractorTests : TestBase
+    public class UpgradeExtractorTests : IntegrationTest
     {
         // Happy path tests
         [Test]

--- a/src/Modules/UserAccess/Application/Users/CreateCurrentUser/PioneerUserCreatedNotification.cs
+++ b/src/Modules/UserAccess/Application/Users/CreateCurrentUser/PioneerUserCreatedNotification.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace SatisfactoryPlanner.Modules.UserAccess.Application.Users.CreateCurrentUser
 {
-    public class PioneerUserCreatedNotification : DomainNotificationBase<PioneerUserCreatedDomainEvent>
+    public class PioneerUserCreatedNotification : DomainEventNotificationBase<PioneerUserCreatedDomainEvent>
     {
         [JsonConstructor]
         public PioneerUserCreatedNotification(PioneerUserCreatedDomainEvent domainEvent, Guid id)

--- a/src/Modules/UserAccess/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
+++ b/src/Modules/UserAccess/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
@@ -1,16 +1,13 @@
 ﻿using Autofac;
-using SatisfactoryPlanner.BuildingBlocks.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 
 namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration.EventsBus
 {
-    internal class EventsBusModule : Module
+    internal class EventsBusModule(IEventsBus eventsBus) : Module
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<InMemoryEventBusClient>()
-                .As<IEventsBus>()
-                .SingleInstance();
+            builder.RegisterInstance(eventsBus).As<IEventsBus>();
         }
     }
 }

--- a/src/Modules/UserAccess/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
+++ b/src/Modules/UserAccess/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
@@ -41,7 +41,7 @@ namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration.Pr
 
                     var result = await _decorated.Handle(command, cancellationToken);
 
-                    _logger.Information("Command processed successfully, result {Result}", result);
+                    _logger.Information("Command {Command} processed successfully, result {Result}", command.GetType().Name, result);
 
                     return result;
                 }

--- a/src/Modules/UserAccess/Infrastructure/Configuration/Processing/ProcessingModule.cs
+++ b/src/Modules/UserAccess/Infrastructure/Configuration/Processing/ProcessingModule.cs
@@ -34,16 +34,14 @@ namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration.Pr
                 .InstancePerLifetimeScope();
 
             builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
-            builder.RegisterGenericDecorator(typeof(DomainEventsDispatcherNotificationHandlerDecorator<>),
-                typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
+
+            builder.RegisterGenericDecorator(typeof(DomainEventsDispatcherNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(LoggingNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
 
             builder.RegisterAssemblyTypes(Assemblies.Application)
                 .AsClosedTypesOf(typeof(IDomainEventNotification<>))

--- a/src/Modules/UserAccess/Infrastructure/Configuration/Quartz/QuartzStartup.cs
+++ b/src/Modules/UserAccess/Infrastructure/Configuration/Quartz/QuartzStartup.cs
@@ -26,21 +26,21 @@ namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration.Qu
             logger.Information("Quartz started.");
         }
 
-        internal static void Shutdown() => _scheduler.Shutdown();
+        internal static void Shutdown() => _scheduler?.Shutdown().Wait();
 
         private static IScheduler StartScheduler(ILogger logger)
         {
+            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
+
             var schedulerConfiguration = new NameValueCollection
             {
                 {
-                    "quartz.scheduler.instanceName", "SatisfactoryPlanner"
+                    "quartz.scheduler.instanceName", "SatisfactoryPlanner.UserAccess"
                 }
             };
 
             var schedulerFactory = new StdSchedulerFactory(schedulerConfiguration);
             var scheduler = schedulerFactory.GetScheduler().GetAwaiter().GetResult();
-
-            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
 
             scheduler.Start().GetAwaiter().GetResult();
 

--- a/src/Modules/UserAccess/Infrastructure/Configuration/UserAccessStartup.cs
+++ b/src/Modules/UserAccess/Infrastructure/Configuration/UserAccessStartup.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using SatisfactoryPlanner.BuildingBlocks.Application;
 using SatisfactoryPlanner.BuildingBlocks.Infrastructure;
+using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 using SatisfactoryPlanner.Modules.UserAccess.Application.Users.CreateCurrentUser;
 using SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration.DataAccess;
 using SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration.Domain;
@@ -16,22 +17,27 @@ using System;
 
 namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration
 {
-    public class UserAccessStartup
+    /// <summary>
+    ///     Initialize the services and configurations for the UserAccess module.
+    ///     Should be called from the main application startup.
+    /// </summary>
+    public static class UserAccessStartup
     {
-        public static void Initialize(
+        public static void Start(
             string connectionString,
             IExecutionContextAccessor executionContextAccessor,
-            ILogger logger)
+            ILogger logger,
+            IEventsBus eventsBus)
         {
             var moduleLogger = logger.ForContext("Module", "UserAccess");
 
             ConfigureCompositionRoot(
                 connectionString,
                 executionContextAccessor,
-                moduleLogger);
+                moduleLogger,
+                eventsBus);
 
             QuartzStartup.Initialize(moduleLogger);
-
             EventsBusStartup.Initialize(moduleLogger);
         }
 
@@ -43,7 +49,8 @@ namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration
         private static void ConfigureCompositionRoot(
             string connectionString,
             IExecutionContextAccessor executionContextAccessor,
-            ILogger logger)
+            ILogger logger,
+            IEventsBus eventsBus)
         {
             var containerBuilder = new ContainerBuilder();
 
@@ -53,7 +60,7 @@ namespace SatisfactoryPlanner.Modules.UserAccess.Infrastructure.Configuration
             containerBuilder.RegisterModule(new DataAccessModule(connectionString, loggerFactory));
             containerBuilder.RegisterModule(new DomainModule());
             containerBuilder.RegisterModule(new ProcessingModule());
-            containerBuilder.RegisterModule(new EventsBusModule());
+            containerBuilder.RegisterModule(new EventsBusModule(eventsBus));
             containerBuilder.RegisterModule(new MediatorModule());
 
             var domainNotificationsMap = new BiDictionary<string, Type>();

--- a/src/Modules/UserAccess/Tests/IntegrationTests/SeedWork/IntegrationTest.cs
+++ b/src/Modules/UserAccess/Tests/IntegrationTests/SeedWork/IntegrationTest.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Npgsql;
 using NSubstitute;
+using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
 using SatisfactoryPlanner.Modules.UserAccess.Application.Contracts;
 using SatisfactoryPlanner.Modules.UserAccess.Infrastructure;
@@ -9,9 +10,11 @@ using Serilog;
 
 namespace SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.SeedWork
 {
-    public class TestBase
+    public class IntegrationTest
     {
         protected string ConnectionString { get; private set; } = default!;
+
+        public IEventsBus EventsBus { get; private set; } = default!;
 
         protected ILogger Logger { get; private set; } = default!;
 
@@ -34,13 +37,15 @@ namespace SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.SeedWork
                 await DatabaseClearer.Clear(connection);
             }
 
-            Logger = Substitute.For<ILogger>();
             ExecutionContext = new ExecutionContextMock(Guid.NewGuid());
+            Logger = Substitute.For<ILogger>();
+            EventsBus = Substitute.For<IEventsBus>();
 
-            UserAccessStartup.Initialize(
+            UserAccessStartup.Start(
                 ConnectionString,
                 ExecutionContext,
-                Logger);
+                Logger,
+                EventsBus);
 
             UserAccessModule = new UserAccessModule();
         }

--- a/src/Modules/UserAccess/Tests/IntegrationTests/Users/CreateUserTests.cs
+++ b/src/Modules/UserAccess/Tests/IntegrationTests/Users/CreateUserTests.cs
@@ -7,7 +7,7 @@ using SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.UserAccess.IntegrationTests.Users
 {
     [TestFixture]
-    public class CreateUserTests : TestBase
+    public class CreateUserTests : IntegrationTest
     {
         [Test]
         public async Task CreatePioneerUser_Test()

--- a/src/Modules/Worlds/Application/Worlds/CreateStarterWorld/WorldCreatedNotification.cs
+++ b/src/Modules/Worlds/Application/Worlds/CreateStarterWorld/WorldCreatedNotification.cs
@@ -4,7 +4,7 @@ using SatisfactoryPlanner.Modules.Worlds.Domain.Worlds.Events;
 
 namespace SatisfactoryPlanner.Modules.Worlds.Application.Worlds.CreateStarterWorld
 {
-    public class WorldCreatedNotification : DomainNotificationBase<WorldCreatedDomainEvent>
+    public class WorldCreatedNotification : DomainEventNotificationBase<WorldCreatedDomainEvent>
     {
         [JsonConstructor]
         public WorldCreatedNotification(WorldCreatedDomainEvent domainEvent, Guid id)

--- a/src/Modules/Worlds/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
+++ b/src/Modules/Worlds/Infrastructure/Configuration/EventsBus/EventsBusModule.cs
@@ -1,16 +1,13 @@
 ﻿using Autofac;
-using SatisfactoryPlanner.BuildingBlocks.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 
 namespace SatisfactoryPlanner.Modules.Worlds.Infrastructure.Configuration.EventsBus
 {
-    internal class EventsBusModule : Module
+    internal class EventsBusModule(IEventsBus eventsBus) : Module
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<InMemoryEventBusClient>()
-                .As<IEventsBus>()
-                .SingleInstance();
+            builder.RegisterInstance(eventsBus).As<IEventsBus>();
         }
     }
 }

--- a/src/Modules/Worlds/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
+++ b/src/Modules/Worlds/Infrastructure/Configuration/Processing/LoggingCommandHandlerWithResultDecorator.cs
@@ -38,7 +38,7 @@ namespace SatisfactoryPlanner.Modules.Worlds.Infrastructure.Configuration.Proces
 
                     var result = await _decorated.Handle(command, cancellationToken);
 
-                    _logger.Information("Command processed successfully, result {Result}", result);
+                    _logger.Information("Command {Command} processed successfully, result {Result}", command.GetType().Name, result);
 
                     return result;
                 }

--- a/src/Modules/Worlds/Infrastructure/Configuration/Processing/ProcessingModule.cs
+++ b/src/Modules/Worlds/Infrastructure/Configuration/Processing/ProcessingModule.cs
@@ -30,18 +30,14 @@ namespace SatisfactoryPlanner.Modules.Worlds.Infrastructure.Configuration.Proces
                 .InstancePerLifetimeScope();
 
             builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(UnitOfWorkCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(ValidationCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
             builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerDecorator<>), typeof(ICommandHandler<>));
-            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>),
-                typeof(ICommandHandler<,>));
+            builder.RegisterGenericDecorator(typeof(LoggingCommandHandlerWithResultDecorator<,>), typeof(ICommandHandler<,>));
 
-            builder.RegisterGenericDecorator(
-                typeof(DomainEventsDispatcherNotificationHandlerDecorator<>),
-                typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(DomainEventsDispatcherNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
+            builder.RegisterGenericDecorator(typeof(LoggingNotificationHandlerDecorator<>), typeof(INotificationHandler<>));
 
             builder.RegisterAssemblyTypes(Assemblies.Application)
                 .AsClosedTypesOf(typeof(IDomainEventNotification<>))

--- a/src/Modules/Worlds/Infrastructure/Configuration/Quartz/QuartzStartup.cs
+++ b/src/Modules/Worlds/Infrastructure/Configuration/Quartz/QuartzStartup.cs
@@ -26,21 +26,21 @@ namespace SatisfactoryPlanner.Modules.Worlds.Infrastructure.Configuration.Quartz
             logger.Information("Quartz started.");
         }
 
-        internal static void Shutdown() => _scheduler.Shutdown();
+        internal static void Shutdown() => _scheduler?.Shutdown().Wait();
 
         private static IScheduler StartScheduler(ILogger logger)
         {
+            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
+
             var schedulerConfiguration = new NameValueCollection
             {
                 {
-                    "quartz.scheduler.instanceName", "SatisfactoryPlanner"
+                    "quartz.scheduler.instanceName", "SatisfactoryPlanner.Worlds"
                 }
             };
 
             var schedulerFactory = new StdSchedulerFactory(schedulerConfiguration);
             var scheduler = schedulerFactory.GetScheduler().GetAwaiter().GetResult();
-
-            LogProvider.SetCurrentLogProvider(new SerilogLogProvider(logger));
 
             scheduler.Start().GetAwaiter().GetResult();
 

--- a/src/Modules/Worlds/Tests/IntegrationTests/Pioneers/PioneerSpawnTests.cs
+++ b/src/Modules/Worlds/Tests/IntegrationTests/Pioneers/PioneerSpawnTests.cs
@@ -8,7 +8,7 @@ using SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork;
 namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.Pioneers
 {
     [TestFixture]
-    public class PioneerSpawnTests : TestBase
+    public class PioneerSpawnTests : IntegrationTest
     {
         [Test]
         public async Task SpawnPioneer_Test()

--- a/src/Modules/Worlds/Tests/IntegrationTests/SatisfactoryPlanner.Modules.Worlds.IntegrationTests.csproj
+++ b/src/Modules/Worlds/Tests/IntegrationTests/SatisfactoryPlanner.Modules.Worlds.IntegrationTests.csproj
@@ -37,6 +37,9 @@
     <ProjectReference Include="..\..\..\..\BuildingBlocks\Domain\SatisfactoryPlanner.BuildingBlocks.Domain.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\BuildingBlocks\Infrastructure\SatisfactoryPlanner.BuildingBlocks.Infrastructure.csproj" >
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\BuildingBlocks\Tests\SatisfactoryPlanner.BuildingBlocks.IntegrationTests\SatisfactoryPlanner.BuildingBlocks.IntegrationTests.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>

--- a/src/Modules/Worlds/Tests/IntegrationTests/SeedWork/DatabaseClearer.cs
+++ b/src/Modules/Worlds/Tests/IntegrationTests/SeedWork/DatabaseClearer.cs
@@ -1,0 +1,22 @@
+﻿using Dapper;
+using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
+using System.Data;
+
+namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork
+{
+    public static class DatabaseClearer
+    {
+        public static async Task Clear(IDbConnection connection)
+        {
+            var sql = ClearDatabaseSqlGenerator.InSchema("worlds")
+                .ClearTable("inbox_messages")
+                .ClearTable("internal_commands")
+                .ClearTable("outbox_messages")
+                .ClearTable("pioneers")
+                .ClearTable("worlds")
+                .GenerateSql();
+
+            await connection.ExecuteScalarAsync(sql);
+        }
+    }
+}

--- a/src/Modules/Worlds/Tests/IntegrationTests/SeedWork/IntegrationTest.cs
+++ b/src/Modules/Worlds/Tests/IntegrationTests/SeedWork/IntegrationTest.cs
@@ -1,5 +1,6 @@
 using Npgsql;
 using NSubstitute;
+using SatisfactoryPlanner.BuildingBlocks.Infrastructure.EventBus;
 using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
 using SatisfactoryPlanner.Modules.Worlds.Application.Contracts;
 using SatisfactoryPlanner.Modules.Worlds.Infrastructure;
@@ -8,9 +9,11 @@ using Serilog;
 
 namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork
 {
-    public class TestBase
+    public class IntegrationTest
     {
         protected string ConnectionString { get; private set; } = null!;
+
+        public IEventsBus EventsBus { get; private set; } = default!;
 
         protected ILogger Logger { get; private set; } = null!;
 
@@ -32,11 +35,13 @@ namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork
 
             Logger = Substitute.For<ILogger>();
             ExecutionContext = new ExecutionContextMock(Guid.NewGuid());
+            EventsBus = Substitute.For<IEventsBus>();
 
-            WorldsStartup.Initialize(
+            WorldsStartup.Start(
                 ConnectionString,
                 ExecutionContext,
-                Logger);
+                Logger,
+                EventsBus);
 
             WorldsModule = new WorldsModule();
         }

--- a/src/Modules/Worlds/Tests/IntegrationTests/SeedWork/TestBase.cs
+++ b/src/Modules/Worlds/Tests/IntegrationTests/SeedWork/TestBase.cs
@@ -1,4 +1,3 @@
-using Dapper;
 using Npgsql;
 using NSubstitute;
 using SatisfactoryPlanner.BuildingBlocks.IntegrationTests;
@@ -6,7 +5,6 @@ using SatisfactoryPlanner.Modules.Worlds.Application.Contracts;
 using SatisfactoryPlanner.Modules.Worlds.Infrastructure;
 using SatisfactoryPlanner.Modules.Worlds.Infrastructure.Configuration;
 using Serilog;
-using System.Data;
 
 namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork
 {
@@ -29,7 +27,7 @@ namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork
 
             await using (var connection = new NpgsqlConnection(ConnectionString))
             {
-                await ClearDatabase(connection);
+                await DatabaseClearer.Clear(connection);
             }
 
             Logger = Substitute.For<ILogger>();
@@ -47,19 +45,6 @@ namespace SatisfactoryPlanner.Modules.Worlds.IntegrationTests.SeedWork
         public void AfterEachTest()
         {
             WorldsStartup.Stop();
-        }
-
-        private static async Task ClearDatabase(IDbConnection connection)
-        {
-            var sql = ClearDatabaseSqlGenerator.InSchema("worlds")
-                .ClearTable("inbox_messages")
-                .ClearTable("internal_commands")
-                .ClearTable("outbox_messages")
-                .ClearTable("pioneers")
-                .ClearTable("worlds")
-                .GenerateSql();
-
-            await connection.ExecuteScalarAsync(sql);
         }
     }
 }


### PR DESCRIPTION
Added a worlds endpoint test and while it ran successfully, I noticed errors being logged in the database and logs that we were trying to insert an inbox_message that already exists. After hours of investigation I figured out that the events bus we were using was being re-used between tests since the tests ran in the same process. This led to the same events being subscribed to more than once. To solve that problem, I moved the instantiation of the events bus to the API and passed it into the modules so that there is more control over its lifetime and we can clear it when the api shuts down. 

Other small fixes were made while investigating to aid in the investigation:
* Quartz logging for the modules was being done too late which made confusing logs
* All quartz schedulers had the same instance name which made it hard to track in logs
* Moved logging out of the events bus client into a decorator around all notification handlers to improve logging
* Turned on logging from the api and requests